### PR TITLE
Configure update strategy for deployment on persistence

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -110,3 +110,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}

--- a/values.yaml
+++ b/values.yaml
@@ -88,6 +88,10 @@ persistence:
   # -- actual storageClass
   storageClass: ""
 
+# when persistence.enabled is set to true, strategy should be changed to 'Recreate'
+updateStrategy:
+  type: RollingUpdate 
+
 # -- @ignore
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This MR adds the values definition for strategy.type with the default value "RollingUpdate".

If you enable persistence on gotify, this needs to be set to "Recreate" assuming you have a standard ReadWriteOnce volume attached. In order to allow for updates, this needs to be configurable.

