### PR TITLE
Make update strategy configurable

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -110,3 +110,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}

--- a/values.yaml
+++ b/values.yaml
@@ -88,6 +88,10 @@ persistence:
   # -- actual storageClass
   storageClass: ""
 
+# when persistence.enabled is set to true, strategy should be changed to 'Recreate'
+updateStrategy:
+  type: RollingUpdate 
+  
 # -- @ignore
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION

his MR makes it possible to set the update strategy for the deployment.

When enabling persistence with a classic ReadWriteOnce volume, the strategy needs to be set to Recreate, in order to perform a successful update.
