### PR TITLE
Make update strategy configurable

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ name: gotify
 description: Gotify - a simple server for sending and receiving messages
 
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: "2.8.0"
 
 home: https://gotify.net/

--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,1 @@
+`helm push gotify-0.7.1.tgz oci://registry-1.docker.io/tobiashvmz`

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -110,3 +110,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}

--- a/values.yaml
+++ b/values.yaml
@@ -88,6 +88,10 @@ persistence:
   # -- actual storageClass
   storageClass: ""
 
+# when persistence.enabled is set to true, strategy should be changed to 'Recreate'
+updateStrategy:
+  type: RollingUpdate 
+
 # -- @ignore
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
When someone uses persistence.enabled and they have a volume with access mode ReadWriteOnce, the update strategy needs to be set to Recreate to prevent updates / upgrades from crashing.

This fix sets the default value as well as making the strategy configurable via values.yaml